### PR TITLE
Add ShellState and Command Parsing Logic

### DIFF
--- a/src/shell/command.rs
+++ b/src/shell/command.rs
@@ -1,0 +1,20 @@
+// RemyShell - A developer-oriented terminal written in Rust
+// Copyright (c) 2026 Samuel Bleau
+// Licensed under the MIT License - see LICENSE file for details
+//
+// File: shell/command.rs
+// Description: Command parsing and execution logic
+
+pub enum Command {
+    Exit,
+    Empty,
+    Raw(String),
+}
+
+pub fn parse_command(input: &str) -> Command {
+    match input {
+        "exit" => Command::Exit,
+        "" => Command::Empty,
+        other => Command::Raw(other.to_string()),
+    }
+}

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -11,4 +11,4 @@ mod command;
 
 pub use repl::Repl;
 pub use state::ShellState;
-pub use command::Command;
+pub use command::{Command, parse_command};

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -6,5 +6,7 @@
 // Description: Shell module providing core shell functionality
 
 mod repl;
+mod state;
 
 pub use repl::Repl;
+pub use state::ShellState;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -7,6 +7,8 @@
 
 mod repl;
 mod state;
+mod command;
 
 pub use repl::Repl;
 pub use state::ShellState;
+pub use command::Command;

--- a/src/shell/repl.rs
+++ b/src/shell/repl.rs
@@ -6,17 +6,22 @@
 // Description: Read-Eval-Print Loop implementation for the shell
 
 use std::io::{Write, BufRead};
+use crate::shell::ShellState;
+use crate::shell::Command;
+use crate::shell::command::parse_command;
 
 pub struct Repl<R: BufRead, W: Write> {
     input: R,
     output: W,
+    state: ShellState
 }
 
 impl<R: BufRead, W: Write> Repl<R, W> {
     pub fn new(input: R, output: W) -> Self {
         Repl {
             input,
-            output
+            output,
+            state: ShellState::new(),
         }
     }
 
@@ -25,16 +30,17 @@ impl<R: BufRead, W: Write> Repl<R, W> {
             self.print_prompt()?;
             let input = self.read_input()?;
 
-            if input.is_empty() {
-                continue;
+            match parse_command(&input) {
+                Command::Exit => {
+                    writeln!(self.output, "Goodbye little rat!")?;
+                    break;
+                }
+                Command::Empty => continue,
+                Command::Raw(cmd) => {
+                    writeln!(self.output, "{cmd}")?;
+                    self.state.last_status = 0;
+                }
             }
-
-            if input == "exit" {
-                writeln!(self.output, "Goodbye little rat!")?;
-                break;
-            }
-
-            writeln!(self.output, "{}", input)?;
         }
         Ok(())
     }

--- a/src/shell/state.rs
+++ b/src/shell/state.rs
@@ -5,4 +5,20 @@
 // File: shell/state.rs
 // Description: Shell state management and persistence
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+pub struct ShellState {
+    pub cwd: PathBuf,
+    pub last_status: i32,
+    pub env: HashMap<String, String>,
+}
 
+impl ShellState {
+    pub fn new() -> Self {
+        Self {
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
+            last_status: 0,
+            env: std::env::vars().collect(),
+        }
+    }
+}

--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -1,0 +1,33 @@
+// RemyShell - A developer-oriented terminal written in Rust
+// Copyright (c) 2026 Samuel Bleau
+// Licensed under the MIT License - see LICENSE file for details
+//
+// File: tests/command_tests
+// Description: Integration tests for command parsing
+
+use remyshell::shell::Command;
+use remyshell::shell::parse_command;
+
+#[test]
+fn parse_exit_command() {
+    match parse_command("exit") {
+        Command::Exit => {}
+        _ => panic!("expected exit command"),
+    }
+}
+
+#[test]
+fn parse_empty_command() {
+    match parse_command("") {
+        Command::Empty => {}
+        _ => panic!("expected empty command"),
+    }
+}
+
+#[test]
+fn parse_raw_command() {
+    match parse_command("hello world") {
+        Command::Raw(value) => assert_eq!(value, "hello world"),
+        _ => panic!("expected raw command"),
+    }
+}

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -1,0 +1,26 @@
+// RemyShell - A developer-oriented terminal written in Rust
+// Copyright (c) 2026 Samuel Bleau
+// Licensed under the MIT License - see LICENSE file for details
+//
+// File: tests/state_tests
+// Description: Integration tests for shell state
+
+use remyshell::shell::ShellState;
+use std::path::PathBuf;
+use std::collections::HashMap;
+
+#[test]
+fn new_state_defaults() {
+    let state = ShellState::new();
+    let expected_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    assert_eq!(state.cwd, expected_cwd);
+    assert_eq!(state.last_status, 0);
+}
+
+#[test]
+fn new_state_env_snapshot() {
+    let expected_env: HashMap<String, String> = std::env::vars().collect();
+    let state = ShellState::new();
+    assert_eq!(state.env, expected_env);
+}
+


### PR DESCRIPTION
This pull request introduces a new command parsing and shell state management system to the RemyShell codebase, along with integration tests for both features. The changes modularize command handling, add persistent shell state, and update the REPL loop to leverage these improvements.

**Command Parsing and Execution:**

* Added the `Command` enum and `parse_command` function in `src/shell/command.rs` to standardize command parsing, distinguishing between exit, empty, and raw commands.
* Updated the REPL loop in `src/shell/repl.rs` to use the new command parser and handle commands accordingly, including printing output and updating last status.

**Shell State Management:**

* Introduced the `ShellState` struct in `src/shell/state.rs`, which tracks the current working directory, last command status, and environment variables, with a constructor to initialize defaults.
* Integrated `ShellState` into the REPL, enabling stateful command execution and persistence.

**Testing:**

* Added integration tests for command parsing in `tests/command_tests.rs`, covering exit, empty, and raw command scenarios.
* Added integration tests for shell state initialization and environment snapshot in `tests/state_tests.rs`.